### PR TITLE
Enable two-way translation setting

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -64,6 +64,8 @@
   "target_language_label": { "message": "Target Language" },
   "source_language_placeholder": { "message": "Enter source language" },
   "target_language_placeholder": { "message": "Enter target language" },
+  "enable_two_way_label": { "message": "Enable 2-Way Translation" },
+  "enable_two_way_description": { "message": "Automatically translate between the selected languages." },
 
   "help_tab_title": { "message": "Help" },
   "about_tab_title": { "message": "What's New" },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -62,6 +62,8 @@
   "target_language_label": { "message": "زبان مقصد" },
   "source_language_placeholder": { "message": "زبان مبدا را وارد کنید" },
   "target_language_placeholder": { "message": "زبان مقصد را وارد کنید" },
+  "enable_two_way_label": { "message": "فعال‌سازی ترجمه دوطرفه" },
+  "enable_two_way_description": { "message": "به‌طور خودکار بین دو زبان انتخاب شده ترجمه می‌کند." },
 
   "help_tab_title": { "message": "راهنما" },
   "about_tab_title": { "message": "تغییرات جدید" },

--- a/html/options.html
+++ b/html/options.html
@@ -209,6 +209,17 @@
                   placeholder="Enter target language"
                 />
               </div>
+              <div class="setting-group">
+                <label for="enableTwoWay" data-i18n="enable_two_way_label"
+                  >Enable 2-Way Translation</label
+                >
+                <input type="checkbox" id="enableTwoWay" />
+                <span
+                  class="setting-description"
+                  data-i18n="enable_two_way_description"
+                  >Automatically translate between the selected languages.</span
+                >
+              </div>
             </section>
           </div>
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-proposal-decorators": "^7.25.9",
     "@babel/plugin-transform-class-properties": "^7.27.1",
     "@babel/preset-env": "^7.26.9",
+    "@eslint/js": "^9.31.0",
     "babel-loader": "^10.0.0",
     "copy-webpack-plugin": "^13.0.0",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@babel/preset-env':
         specifier: ^7.26.9
         version: 7.26.9(@babel/core@7.26.10)
+      '@eslint/js':
+        specifier: ^9.31.0
+        version: 9.31.0
       babel-loader:
         specifier: ^10.0.0
         version: 10.0.0(@babel/core@7.26.10)(webpack@5.98.0)
@@ -686,6 +689,10 @@ packages:
 
   '@eslint/js@9.22.0':
     resolution: {integrity: sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.31.0':
+    resolution: {integrity: sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
@@ -2631,6 +2638,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@9.22.0': {}
+
+  '@eslint/js@9.31.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 

--- a/src/config.js
+++ b/src/config.js
@@ -62,6 +62,7 @@ export const CONFIG = {
   TRANSLATE_ON_TEXT_SELECTION: true, // فعال کردن ترجمه با انتخاب متن در صفحه
   REQUIRE_CTRL_FOR_TEXT_SELECTION: false, // نیاز به نگه داشتن Ctrl هنگام انتخاب متن
   ENABLE_DICTIONARY: true, // با مکانیزم تشخیص کلمه، بعنوان دیکشنری پاسخ را نمایش میدهد
+  ENABLE_TWO_WAY: true, // به طور خودکار بین دو زبان انتخاب شده ترجمه می‌کند
 
   // --- UI & Styling ---
   HIGHTLIH_NEW_ELEMETN_RED: "2px solid red", // Note: typo in original key 'HIGHTLIH'? Should be HIGHLIGHT?
@@ -328,6 +329,10 @@ export const getTargetLanguageAsync = async () => {
 
 export const getEnableDictionaryAsync = async () => {
   return getSettingValueAsync("ENABLE_DICTIONARY", CONFIG.ENABLE_DICTIONARY);
+};
+
+export const getEnableTwoWayAsync = async () => {
+  return getSettingValueAsync("ENABLE_TWO_WAY", CONFIG.ENABLE_TWO_WAY);
 };
 
 export const getPromptAsync = async () => {

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -28,6 +28,7 @@ import { delay, isExtensionContextValid, logME } from "../utils/helpers.js";
 import { buildPrompt } from "../utils/promptBuilder.js";
 import { isPersianText } from "../utils/textDetection.js";
 import { AUTO_DETECT_VALUE } from "../utils/tts.js";
+import { normalizeLangCode } from "../utils/langUtils.js";
 import { ErrorTypes } from "../services/ErrorTypes.js";
 import { getLanguageCode } from "../utils/tts.js";
 
@@ -595,13 +596,11 @@ class ApiService {
     if (twoWayEnabled) {
       try {
         const detection = await Browser.i18n.detectLanguage(text);
-        const detected = detection?.languages?.[0]?.language?.split("-")[0];
-        const srcCode = getLanguageCode(sourceLanguage).split("-")[0];
-        const tgtCode = getLanguageCode(targetLanguage).split("-")[0];
-        if (detected) {
-          if (detected === tgtCode) {
-            [sourceLanguage, targetLanguage] = [targetLanguage, sourceLanguage];
-          }
+        const detected = normalizeLangCode(detection?.languages?.[0]?.language);
+        const srcCode = normalizeLangCode(getLanguageCode(sourceLanguage));
+        const tgtCode = normalizeLangCode(getLanguageCode(targetLanguage));
+        if (detected && detected === tgtCode) {
+          [sourceLanguage, targetLanguage] = [targetLanguage, sourceLanguage];
         }
       } catch (e) {
         logME("[TwoWay] Language detection failed", e);
@@ -638,8 +637,8 @@ class ApiService {
           detectionResult.languages.length > 0
         ) {
           const mainDetection = detectionResult.languages[0];
-          const detectedLangCode = mainDetection.language.split("-")[0];
-          const targetLangCode = getLanguageCode(targetLanguage).split("-")[0];
+          const detectedLangCode = normalizeLangCode(mainDetection.language);
+          const targetLangCode = normalizeLangCode(getLanguageCode(targetLanguage));
 
           let performSwap = false;
           let reason = "";
@@ -670,7 +669,7 @@ class ApiService {
           logME(
             "[API Logic] Language detection was not reliable. Using Regex fallback."
           );
-          const targetLangCode = getLanguageCode(targetLanguage).split("-")[0];
+          const targetLangCode = normalizeLangCode(getLanguageCode(targetLanguage));
 
           // اگر متن حاوی حروف فارسی/عربی است و زبان مقصد هم یکی از این زبان‌هاست
 

--- a/src/options.js
+++ b/src/options.js
@@ -168,6 +168,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const resetPromptButton = document.getElementById("resetPromptButton");
   const sourceLangNameSpan = document.getElementById("sourceLangName");
   const targetLangNameSpan = document.getElementById("targetLangName");
+  const enableTwoWayCheckbox = document.getElementById("enableTwoWay");
   const excludedSites = document.getElementById("excludedSites");
 
   // --- Event Listener for the new Reset Button ---
@@ -646,6 +647,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         CONFIG.TRANSLATE_ON_TEXT_FIELDS,
       ENABLE_DICTIONARY:
         enableDictionraryCheckbox?.checked ?? CONFIG.ENABLE_DICTIONARY,
+      ENABLE_TWO_WAY: enableTwoWayCheckbox?.checked ?? CONFIG.ENABLE_TWO_WAY,
       ENABLE_SHORTCUT_FOR_TEXT_FIELDS:
         enableShortcutForTextFieldsCheckbox?.checked ??
         CONFIG.ENABLE_SHORTCUT_FOR_TEXT_FIELDS,
@@ -761,6 +763,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (enableDictionraryCheckbox)
         enableDictionraryCheckbox.checked =
           settings.ENABLE_DICTIONARY ?? CONFIG.ENABLE_DICTIONARY;
+      if (enableTwoWayCheckbox)
+        enableTwoWayCheckbox.checked =
+          settings.ENABLE_TWO_WAY ?? CONFIG.ENABLE_TWO_WAY;
 
       // Populate text inputs and textareas
       if (sourceLanguageInput)

--- a/src/utils/langUtils.js
+++ b/src/utils/langUtils.js
@@ -25,6 +25,27 @@ export function resolveLangCode(inputLang) {
   return "en"; // اگر پیدا نشد fallback
 }
 
+/**
+ * Normalize language codes to handle legacy variants.
+ * Converts codes like 'iw' to 'he'. Only returns the base 2-letter code.
+ * @param {string} code
+ * @returns {string|null}
+ */
+export function normalizeLangCode(code) {
+  if (!code) return code;
+  const base = code.toLowerCase().split("-")[0];
+  switch (base) {
+    case "iw":
+      return "he"; // Hebrew legacy code
+    case "in":
+      return "id"; // Indonesian legacy code
+    case "ji":
+      return "yi"; // Yiddish legacy code
+    default:
+      return base;
+  }
+}
+
 export async function getEffectiveLanguage(
   text,
   selectedLang,


### PR DESCRIPTION
## Summary
- add new `ENABLE_TWO_WAY` configuration option
- save/load new option in settings page
- show checkbox for two-way translation in options UI
- detect text language and swap languages automatically when enabled
- localize new strings in English and Farsi locales

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874e674b8008321a297abe8ddbd66b1