### PR TITLE
Add Google Translate link

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -297,6 +297,8 @@
   "popup_copy_target_title_icon": { "message": "Copy target text" },
   "popup_voice_target_alt_icon": { "message": "Speak target" },
   "popup_voice_target_title_icon": { "message": "Speak" },
+  "popup_open_in_google_translate_link": { "message": "Open in Google Translate" },
+  "popup_open_in_google_translate_title": { "message": "View this text on Google Translate" },
   "popup_string_during_translate": { "message": "translating..." },
   "popup_string_error_sending": { "message": "Error sending request." },
   "popup_string_error_response_empty": { "message": "(translation is empty)" },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -301,6 +301,8 @@
   "popup_copy_target_title_icon": { "message": "کپی" },
   "popup_voice_target_alt_icon": { "message": "تلفظ مقصد" },
   "popup_voice_target_title_icon": { "message": "تلفظ" },
+  "popup_open_in_google_translate_link": { "message": "مشاهده در گوگل ترنسلیت" },
+  "popup_open_in_google_translate_title": { "message": "باز کردن متن در گوگل ترنسلیت" },
   "popup_string_during_translate": { "message": "در حال ترجمه..." },
   "popup_string_error_sending": { "message": "خطا در ارسال درخواست." },
   "popup_string_error_response_empty": { "message": "(ترجمه یافت نشد)" },

--- a/html/popup.html
+++ b/html/popup.html
@@ -201,6 +201,14 @@
             />
           </div>
           <div id="translationResult" class="result aiwc-popup-markdown"></div>
+          <a
+            id="googleResultLink"
+            target="_blank"
+            class="toolbar-link google-translate-link"
+            rel="noopener"
+            data-i18n="popup_open_in_google_translate_link"
+            data-i18n-title="popup_open_in_google_translate_title"
+          ></a>
         </div>
       </form>
     </div>

--- a/src/popup/domElements.js
+++ b/src/popup/domElements.js
@@ -10,6 +10,7 @@ export default {
   translationForm: $("translationForm"),
   sourceText: $("sourceText"),
   translationResult: $("translationResult"),
+  googleResultLink: $("googleResultLink"),
   sourceContainer: $("sourceText")?.parentElement,
   resultContainer: $("translationResult")?.parentElement,
 

--- a/src/popup/headerActionsManager.js
+++ b/src/popup/headerActionsManager.js
@@ -19,6 +19,9 @@ function setupEventListeners() {
       .then(async () => {
         elements.sourceText.value = "";
         elements.translationResult.textContent = "";
+        if (elements.googleResultLink) {
+          elements.googleResultLink.style.display = "none";
+        }
         uiManager.toggleInlineToolbarVisibility(elements.sourceText);
         uiManager.toggleInlineToolbarVisibility(elements.translationResult);
 

--- a/src/popup/translationManager.js
+++ b/src/popup/translationManager.js
@@ -45,6 +45,10 @@ async function handleTranslationResponse(
   sourceLangIdentifier,
   targetLangIdentifier
 ) {
+  // Hide Google Translate link by default
+  if (elements.googleResultLink) {
+    elements.googleResultLink.style.display = "none";
+  }
   // ❶ WebExtension channel error
   if (Browser.runtime.lastError) {
     const msg = Browser.runtime.lastError.message;
@@ -76,6 +80,26 @@ async function handleTranslationResponse(
     elements.translationResult.classList.add("fade-in");
 
     correctTextDirection(elements.translationResult, translated);
+
+    if (elements.googleResultLink) {
+      const sl =
+        getLanguageCode(sourceLangIdentifier) ||
+        response.data.detectedSourceLang ||
+        "auto";
+      const tl = getLanguageCode(targetLangIdentifier) || "auto";
+      const encoded = encodeURIComponent(textToTranslate);
+      elements.googleResultLink.href =
+        `https://translate.google.com/?sl=${sl}&tl=${tl}&text=${encoded}&op=translate`;
+      elements.googleResultLink.textContent =
+        (await getTranslationString(
+          "popup_open_in_google_translate_link"
+        )) || "Open in Google Translate";
+      elements.googleResultLink.title =
+        (await getTranslationString(
+          "popup_open_in_google_translate_title"
+        )) || "Open in Google Translate";
+      elements.googleResultLink.style.display = "inline-block";
+    }
 
     const sourceLangCode = getLanguageCode(sourceLangIdentifier);
     const targetLangCode = getLanguageCode(targetLangIdentifier);
@@ -134,6 +158,9 @@ async function handleTranslationResponse(
     elements.translationResult.innerHTML = "";
     elements.translationResult.textContent = msg;
     correctTextDirection(elements.translationResult, msg);
+    if (elements.googleResultLink) {
+      elements.googleResultLink.style.display = "none";
+    }
 
     logME("[Translate-Popup] API error:", msg);
   }
@@ -146,6 +173,10 @@ async function triggerTranslation() {
   const textToTranslate = elements.sourceText.value.trim();
   const targetLangIdentifier = elements.targetLanguageInput.value.trim();
   const sourceLangIdentifier = elements.sourceLanguageInput.value.trim();
+
+  if (elements.googleResultLink) {
+    elements.googleResultLink.style.display = "none";
+  }
 
   if (!textToTranslate) {
     elements.sourceText.focus();

--- a/styles/popup.css
+++ b/styles/popup.css
@@ -612,3 +612,18 @@ input:checked + .slider:before {
     transform: translateY(0);
   }
 }
+
+/* Link below translation result to open Google Translate */
+.google-translate-link {
+  display: none;
+  margin-top: 4px;
+  font-size: 12px;
+  text-decoration: none;
+  color: var(--toolbar-link-color);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
+.google-translate-link:hover {
+  background-color: var(--toolbar-link-hover-bg-color);
+}


### PR DESCRIPTION
## Summary
- add Google Translate link to popup
- support new link in English and Farsi locales
- expose googleResultLink in DOM elements
- hide/show the link in header and translation managers
- style google translate link

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876149bf500832182d8b501d0a264f6